### PR TITLE
[APPS-3979] Add include files without chunk option

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ AssetsWebpackPlugin.prototype = {
       if (self.options.entrypoints) {
         chunks = Object.keys(stats.entrypoints)
         if (self.options.includeFilesWithoutChunk) {
-          chunks.push('') // push "unamed" chunk
+          chunks.push('') // push "unnamed" chunk
         }
       } else {
         chunks = Object.keys(stats.assetsByChunkName)

--- a/index.js
+++ b/index.js
@@ -63,6 +63,9 @@ AssetsWebpackPlugin.prototype = {
 
       if (self.options.entrypoints) {
         chunks = Object.keys(stats.entrypoints)
+        if (self.options.includeFilesWithoutChunk) {
+          chunks.push('') // push "unamed" chunk
+        }
       } else {
         chunks = Object.keys(stats.assetsByChunkName)
         chunks.push('') // push "unamed" chunk
@@ -72,7 +75,7 @@ AssetsWebpackPlugin.prototype = {
         var assets
 
         if (self.options.entrypoints) {
-          assets = stats.entrypoints[chunkName].assets
+          assets = (self.options.includeFilesWithoutChunk && chunkName) ? stats.entrypoints[chunkName].assets : stats.assets
         } else {
           assets = chunkName ? stats.assetsByChunkName[chunkName] : stats.assets
         }

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ AssetsWebpackPlugin.prototype = {
         }
       } else {
         chunks = Object.keys(stats.assetsByChunkName)
-        chunks.push('') // push "unamed" chunk
+        chunks.push('') // push "unnamed" chunk
       }
 
       var output = chunks.reduce(function (chunkMap, chunkName) {

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ AssetsWebpackPlugin.prototype = {
         var assets
 
         if (self.options.entrypoints) {
-          assets = (self.options.includeFilesWithoutChunk && chunkName) ? stats.entrypoints[chunkName].assets : stats.assets
+          assets = chunkName ? stats.entrypoints[chunkName].assets : stats.assets
         } else {
           assets = chunkName ? stats.assetsByChunkName[chunkName] : stats.assets
         }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function AssetsWebpackPlugin (options) {
     useCompilerPath: false,
     fileTypes: ['js', 'css'],
     includeAllFileTypes: true,
+    includeFilesWithoutChunk: false,
     keepInMemory: false,
     integrity: false
   }, options)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myglam/assets-webpack-plugin",
-  "version": "3.9.10",
+  "version": "3.10.0",
   "description": "Emits a json file with assets paths",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "assets-webpack-plugin",
+  "name": "@myglam/assets-webpack-plugin",
   "version": "3.9.10",
   "description": "Emits a json file with assets paths",
   "main": "dist/index.js",

--- a/readme.md
+++ b/readme.md
@@ -254,7 +254,7 @@ new AssetsPlugin({fileTypes: ['js', 'jpg']})
 
 Optional. `false` by default.
 
-When set true, includes the assets with no chunk ("unnamed chunk") in the assets file.
+When set to `true`, includes the assets with no chunk ("unnamed chunk") in the assets file.
 
 ```js
 new AssetsPlugin({includeFilesWithoutChunk: true})

--- a/readme.md
+++ b/readme.md
@@ -164,7 +164,7 @@ from the assets json output, and order of import is important.
 
 ```js
 new AssetsPlugin({manifestFirst: true})
-``` 
+```
 
 #### `path`
 
@@ -248,6 +248,16 @@ When set and `includeAllFileTypes` is set false, only assets matching these type
 
 ```js
 new AssetsPlugin({fileTypes: ['js', 'jpg']})
+```
+
+#### `includeFilesWithoutChunk`
+
+Optional. `false` by default.
+
+When set true, includes the assets with no chunk ("unnamed chunk") in the assets file.
+
+```js
+new AssetsPlugin({includeFilesWithoutChunk: true})
 ```
 
 #### `keepInMemory`


### PR DESCRIPTION
### Changes
Added a new option named `includeFilesWithoutChunk` which works by including files that aren't a chunk ("unnamed chunk") to the assets file. This is intended for getting global files, such as fonts and images that are imported by scss/css files.

### Jira Ticket
https://ipsycorp.atlassian.net/browse/APPS-3979

### Related People
\cc @ucarbehlul @mkteh95 @whotemp @matiasherranz @ipsy-facundo 
